### PR TITLE
Do not leak any credentials from DSN when connection fails

### DIFF
--- a/Tests/Transport/ConnectionTest.php
+++ b/Tests/Transport/ConnectionTest.php
@@ -559,10 +559,10 @@ class ConnectionTest extends TestCase
         $connection->publish('{}', [], 120000);
     }
 
-    public function testObfuscatePasswordInDsn()
+    public function testNoCredentialLeakageWhenConnectionFails()
     {
         $this->expectException(\AMQPException::class);
-        $this->expectExceptionMessage('Could not connect to the AMQP server. Please verify the provided DSN. ({"host":"localhost","port":5672,"vhost":"/","login":"user","password":"********"})');
+        $this->expectExceptionMessage('Could not connect to the AMQP server. Please verify the provided DSN.');
         $factory = new TestAmqpFactory(
             $amqpConnection = $this->createMock(\AMQPConnection::class),
             $amqpChannel = $this->createMock(\AMQPChannel::class),

--- a/Transport/Connection.php
+++ b/Transport/Connection.php
@@ -495,11 +495,7 @@ class Connection
             try {
                 $connection->{$connectMethod}();
             } catch (\AMQPConnectionException $e) {
-                $credentials = $this->connectionOptions;
-                $credentials['password'] = '********';
-                unset($credentials['delay']);
-
-                throw new \AMQPException(sprintf('Could not connect to the AMQP server. Please verify the provided DSN. (%s).', json_encode($credentials, \JSON_UNESCAPED_SLASHES)), 0, $e);
+                throw new \AMQPException('Could not connect to the AMQP server. Please verify the provided DSN.', 0, $e);
             }
             $this->amqpChannel = $this->amqpFactory->createChannel($connection);
 


### PR DESCRIPTION
I noticed that when the connection to AMQP fails for whatever reason all the DSK credentials are leaked.

```
Aug 24 15:58:40 CRITICAL: Error thrown while running command "messenger:consume async". 
Message: "Could not connect to the AMQP server. Please verify the provided DSN. 
({"host":my-hostname-on-some-server","port":my-port,"vhost":"the-real-vhost",
"login":"the-real-username","password":"********"})
```

Yes, the password is masked. But it still leaks the server, port, username and vhost.

I think these things should be private and not be logged to a logger server or error capture service.
