### PR TITLE
feat(consume): Use consume instead of get for envelope retrievement

### DIFF
--- a/Tests/Transport/AmqpReceiverTest.php
+++ b/Tests/Transport/AmqpReceiverTest.php
@@ -38,7 +38,7 @@ class AmqpReceiverTest extends TestCase
         $amqpEnvelope = $this->createAMQPEnvelope();
         $connection = $this->createMock(Connection::class);
         $connection->method('getQueueNames')->willReturn(['queueName']);
-        $connection->method('get')->with('queueName')->willReturn($amqpEnvelope);
+        $connection->method('consume')->with('queueName')->willReturn([$amqpEnvelope]);
 
         $receiver = new AmqpReceiver($connection, $serializer);
         $actualEnvelopes = iterator_to_array($receiver->get());

--- a/Tests/Transport/AmqpTransportTest.php
+++ b/Tests/Transport/AmqpTransportTest.php
@@ -46,7 +46,7 @@ class AmqpTransportTest extends TestCase
 
         $serializer->method('decode')->with(['body' => 'body', 'headers' => ['my' => 'header']])->willReturn(new Envelope($decodedMessage));
         $connection->method('getQueueNames')->willReturn(['queueName']);
-        $connection->method('get')->with('queueName')->willReturn($amqpEnvelope);
+        $connection->method('consume')->with('queueName')->willReturn([$amqpEnvelope]);
 
         $envelopes = iterator_to_array($transport->get());
         $this->assertSame($decodedMessage, $envelopes[0]->getMessage());


### PR DESCRIPTION
Dear symfony community,
the rabbitmq docs state that polling is "very inefficient" and "highly discouraged" (see [Production Checklist](https://www.rabbitmq.com/production-checklist.html#apps-polling-consumers) and [Consumers](https://www.rabbitmq.com/consumers.html#fetching).
I wondered why the amqp-messenger uses this feature and would like to discuss if migrating to the "consume-API" is possible. In our project, we need to process millions of messages and I think the community would benefit from this change in terms of performance "per default".
Moreover, we then should set a sensible read_timeout per default, because the process would block endlessly if no new message is received and the "--time_limit" messenger option could not be enforced (setting it is possible through the transport options at this point: [Config](https://github.com/florianPat/amqp-messenger-usage/blob/main/config/packages/messenger.yaml#L21).

Thanks for your feedback,
Flo